### PR TITLE
Update connector version & provide graceful shutdown.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,5 +8,5 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "1.1.0",
   "org.apache.spark" %% "spark-streaming" % "1.1.0",
   "org.apache.spark" %% "spark-sql" % "1.1.0",
-  "com.datastax.spark" %% "spark-cassandra-connector" % "1.1.0-alpha2"
+  "com.datastax.spark" %% "spark-cassandra-connector" % "1.1.0"
 )

--- a/src/main/scala/Test.scala
+++ b/src/main/scala/Test.scala
@@ -80,9 +80,7 @@ object Test {
 
     // https://twitter.com/pwendell/status/580242656082546688
     sys.ShutdownHookThread {
-      log.info("Gracefully stopping Spark Streaming Application")
       ssc.stop(true, true)
-      log.info("Application stopped.")
     }
 
     lazy val cc = CassandraConnector(sc.getConf)

--- a/src/main/scala/Test.scala
+++ b/src/main/scala/Test.scala
@@ -78,6 +78,13 @@ object Test {
     lazy val sc = new SparkContext(conf)
     lazy val ssc = new StreamingContext(sc, Seconds(1))
 
+    // https://twitter.com/pwendell/status/580242656082546688
+    sys.ShutdownHookThread {
+      log.info("Gracefully stopping Spark Streaming Application")
+      ssc.stop(true, true)
+      log.info("Application stopped.")
+    }
+
     lazy val cc = CassandraConnector(sc.getConf)
     createSchema(cc, cassandraKeyspace, cassandraCfCounters, cassandraCfEvents)
 


### PR DESCRIPTION
The current example uses the spark-cassandra connector version `1.1.0-alpha2` which throws a `NoSuchMethodError`:

```
Exception in thread "main" java.lang.NoSuchMethodError: com.datastax.spark.connector.writer.RowWriterFactory$.defaultRowWriterFactory(Lscala/reflect/ClassTag;Lcom/datastax/spark/connector/mapper/ColumnMapper;)Lcom/datastax/spark/connector/writer/RowWriterFactory;
    at Test$.main(Test.scala:98)
    at Test.main(Test.scala)
```

If updated to the latest, stable version of the connector, this will go away. 

Also, if you do not hook into the shutdown process - then you will potentially loss data. Patrick Wendell recently [tweeted](https://twitter.com/pwendell/status/580242656082546688) a link to how you can hook into shutdown and have your Spark Streaming job [handle the SIGTERM signal](http://metabroadcast.com/blog/stop-your-spark-streaming-application-gracefully) sent to the driver. 

It looks something like: 

``` Scala
  sys.ShutdownHookThread {
      log.info("Gracefully stopping Spark Streaming Application")
      ssc.stop(true, true)
      log.info("Application stopped")
  }
```

For Java, it seems that you can hook into shutdown as well (mentioned in the blog too). 
